### PR TITLE
GHCR

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - 'kathy-ghcr'
+      - 'main'
   release:
     types:
       - created

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ghcr.io/moveonorg/spoke
+            ghcr.io/moveonorg/moveon-spoke
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - 'main'
+      - 'kathy-ghcr'
   release:
     types:
       - created


### PR DESCRIPTION
## Description

StateVoices currently doesn't have GHCR set up on their GitHub organization, so the GH Action to build a Spoke Docker image fails.

Since MoveOn has their own separate branch, we should be pushing to our own GHCR anyway, not overwriting StateVoices every time we do a push on `main`.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
