### PR TITLE
Update campaign_contact.updated_at on change

### DIFF
--- a/migrations/20240503180901_campaigncontactsupdatedat.js
+++ b/migrations/20240503180901_campaigncontactsupdatedat.js
@@ -1,0 +1,32 @@
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+
+const { onUpdateTrigger } = require('./helpers/index')
+const ON_UPDATE_TIMESTAMP_FUNCTION = `
+  CREATE OR REPLACE FUNCTION on_update_timestamp()
+  RETURNS trigger AS $$
+  BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+  END;
+$$ language 'plpgsql';
+`
+
+const DROP_ON_UPDATE_TIMESTAMP_FUNCTION = `DROP FUNCTION on_update_timestamp`
+
+exports.up = async function(knex) {
+    await knex.raw(ON_UPDATE_TIMESTAMP_FUNCTION);
+    await knex.raw(onUpdateTrigger('campaign_contact'));
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+    await knex.raw("DROP TRIGGER campaign_contact_updated_at on campaign_contact");
+    await knex.raw(DROP_ON_UPDATE_TIMESTAMP_FUNCTION);
+};

--- a/migrations/helpers/index.js
+++ b/migrations/helpers/index.js
@@ -11,3 +11,11 @@ exports.redefineSqliteTable = async (knex, tableName, newTableFn) => {
   await knex.schema.dropTable(tableName);
   await knex.schema.createTable(tableName, newTableFn);
 };
+
+
+exports.onUpdateTrigger = table => `
+CREATE TRIGGER ${table}_updated_at
+BEFORE UPDATE ON ${table}
+FOR EACH ROW
+EXECUTE PROCEDURE on_update_timestamp();
+`


### PR DESCRIPTION
# Fixes #2361

## Description

Add a trigger on the campaign_contact table to update the "updated_at" column whenever changes are made to the table.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
N/A - change is a database migration
- [ ] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
N/A - change is a database migration
- [X] My PR is labeled [WIP] if it is in progress
