### PR TITLE
Add dynamic replies feature

### DIFF
--- a/__test__/server/api/campaign/campaign.test.js
+++ b/__test__/server/api/campaign/campaign.test.js
@@ -37,6 +37,7 @@ import {
   sleep,
   startCampaign
 } from "../../../test_helpers";
+import { dynamicReassignMutation } from "../../../../src/containers/AssignReplies";
 
 let testAdminUser;
 let testInvite;
@@ -828,6 +829,8 @@ describe("Reassignments", () => {
       },
       testTexterUser2
     );
+    // TEXTER 1 (60 needsMessage, 2 needsResponse, 4 messaged)
+    // TEXTER 2 (25 needsMessage, 3 convo, 1 messaged)
     expect(texterCampaignDataResults.data.assignment.contacts.length).toEqual(
       2
     );
@@ -839,6 +842,105 @@ describe("Reassignments", () => {
     );
     expect(texterCampaignDataResults2.data.assignment.allContactsCount).toEqual(
       29
+    );
+    await runGql(
+      dynamicReassignMutation,
+      {
+        organizationUuid: testCampaign.joinToken,
+        campaignId: testCampaign.id,
+      },
+      testTexterUser2
+    );
+     // TEXTER 1 (60 needsMessage, 4 messaged)
+    // TEXTER 2 (25 needsMessage, 2 needsResponse, 3 convo, 1 messaged)
+    texterCampaignDataResults = await runGql(
+      TexterTodoQuery,
+      {
+        contactsFilter: {
+          messageStatus: "needsResponse",
+          isOptedOut: false,
+          validTimezone: true
+        },
+        assignmentId,
+        organizationId
+      },
+      testTexterUser
+    );
+
+    texterCampaignDataResults2 = await runGql(
+      TexterTodoQuery,
+      {
+        contactsFilter: {
+          messageStatus: "needsResponse",
+          isOptedOut: false,
+          validTimezone: true
+        },
+        assignmentId: assignmentId2,
+        organizationId
+      },
+      testTexterUser2
+    );
+    expect(texterCampaignDataResults.data.assignment.contacts.length).toEqual(
+      2
+    );
+    expect(texterCampaignDataResults.data.assignment.allContactsCount).toEqual(
+      66
+    );
+    expect(texterCampaignDataResults2.data.assignment.contacts.length).toEqual(
+      0
+    );
+    expect(texterCampaignDataResults2.data.assignment.allContactsCount).toEqual(
+      29
+    );
+    jest.useFakeTimers()
+    jest.advanceTimersByTime(4000000)
+    await runGql(
+      dynamicReassignMutation,
+      {
+        organizationUuid: testCampaign.joinToken,
+        campaignId: testCampaign.id,
+      },
+      testTexterUser2
+    );
+    jest.useRealTimers()
+    texterCampaignDataResults = await runGql(
+      TexterTodoQuery,
+      {
+        contactsFilter: {
+          messageStatus: "needsResponse",
+          isOptedOut: false,
+          validTimezone: true
+        },
+        assignmentId,
+        organizationId
+      },
+      testTexterUser
+    );
+
+    texterCampaignDataResults2 = await runGql(
+      TexterTodoQuery,
+      {
+        contactsFilter: {
+          messageStatus: "needsResponse",
+          isOptedOut: false,
+          validTimezone: true
+        },
+        assignmentId: assignmentId2,
+        organizationId
+      },
+      testTexterUser2
+    );
+    expect(texterCampaignDataResults.data.assignment.contacts.length).toEqual(
+      0
+    );
+    expect(texterCampaignDataResults.data.assignment.allContactsCount).toEqual(
+      64
+    );
+    expect(texterCampaignDataResults2.data.assignment.contacts.length).toEqual(
+      2
+    );
+    expect(texterCampaignDataResults2.data.assignment.allContactsCount).toEqual(
+      31
     );
   }, 10000); // long test can exceed default 5seconds
 });

--- a/__test__/server/api/campaign/campaign.test.js
+++ b/__test__/server/api/campaign/campaign.test.js
@@ -846,13 +846,11 @@ describe("Reassignments", () => {
     await runGql(
       dynamicReassignMutation,
       {
-        organizationUuid: testCampaign.joinToken,
+        joinToken: testCampaign.joinToken,
         campaignId: testCampaign.id,
       },
       testTexterUser2
     );
-     // TEXTER 1 (60 needsMessage, 4 messaged)
-    // TEXTER 2 (25 needsMessage, 2 needsResponse, 3 convo, 1 messaged)
     texterCampaignDataResults = await runGql(
       TexterTodoQuery,
       {
@@ -897,7 +895,7 @@ describe("Reassignments", () => {
     await runGql(
       dynamicReassignMutation,
       {
-        organizationUuid: testCampaign.joinToken,
+        joinToken: testCampaign.joinToken,
         campaignId: testCampaign.id,
       },
       testTexterUser2
@@ -930,6 +928,8 @@ describe("Reassignments", () => {
       },
       testTexterUser2
     );
+    // TEXTER 1 (60 needsMessage, 4 messaged)
+    // TEXTER 2 (25 needsMessage, 2 needsResponse, 3 convo, 1 messaged)
     expect(texterCampaignDataResults.data.assignment.contacts.length).toEqual(
       0
     );

--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -359,6 +359,7 @@ export async function createCampaign(
   const campaignQuery = `mutation createCampaign($input: CampaignInput!) {
     createCampaign(campaign: $input) {
       id
+      joinToken
     }
   }`;
   const variables = {

--- a/src/api/campaign.js
+++ b/src/api/campaign.js
@@ -137,6 +137,8 @@ export const schema = gql`
     messageServiceLink: String
     phoneNumbers: [String]
     inventoryPhoneNumberCounts: [CampaignPhoneNumberCount]
+    useDynamicReplies: Boolean
+    replyBatchSize: Int
   }
 
   type CampaignsList {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -399,7 +399,7 @@ const rootSchema = gql`
       newTexterUserId: String!
     ): [CampaignIdAssignmentId]
     dynamicReassign(
-      organizationUuid: String!
+      joinToken: String!
       campaignId: String!
     ): String
     importCampaignScript(campaignId: String!, url: String!): Int

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -99,6 +99,8 @@ const rootSchema = gql`
     texterUIConfig: TexterUIConfigInput
     timezone: String
     inventoryPhoneNumberCounts: [CampaignPhoneNumberInput!]
+    useDynamicReplies: Boolean
+    replyBatchSize: Int
   }
 
   input OrganizationInput {
@@ -395,6 +397,10 @@ const rootSchema = gql`
       messageTextFilter: String
       newTexterUserId: String!
     ): [CampaignIdAssignmentId]
+    dynamicReassign(
+      organizationUuid: String!
+      campaignId: String!
+    ): String
     importCampaignScript(campaignId: String!, url: String!): Int
     createTag(organizationId: String!, tagData: TagInput!): Tag
     editTag(organizationId: String!, id: String!, tagData: TagInput!): Tag

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -101,6 +101,7 @@ const rootSchema = gql`
     inventoryPhoneNumberCounts: [CampaignPhoneNumberInput!]
     useDynamicReplies: Boolean
     replyBatchSize: Int
+    joinToken: String
   }
 
   input OrganizationInput {

--- a/src/components/CampaignDynamicAssignmentForm.jsx
+++ b/src/components/CampaignDynamicAssignmentForm.jsx
@@ -7,6 +7,7 @@ import GSTextField from "../components/forms/GSTextField";
 import * as yup from "yup";
 import Form from "react-formal";
 import OrganizationJoinLink from "./OrganizationJoinLink";
+import OrganizationReassignLink from "./OrganizationReassignLink";
 import { dataTest } from "../lib/attributes";
 import cloneDeep from "lodash/cloneDeep";
 import TagChips from "./TagChips";
@@ -53,7 +54,7 @@ class CampaignDynamicAssignmentForm extends React.Component {
 
   render() {
     const { joinToken, campaignId, organization } = this.props;
-    const { useDynamicAssignment, batchPolicies } = this.state;
+    const { useDynamicAssignment, batchPolicies, useDynamicReplies } = this.state;
     const unselectedPolicies = organization.batchPolicies
       .filter(p => !batchPolicies.find(cur => cur === p))
       .map(p => ({ id: p, name: p }));
@@ -73,6 +74,7 @@ class CampaignDynamicAssignmentForm extends React.Component {
           label="Allow texters with a link to join and start texting when the campaign is started?"
           labelPlacement="start"
         />
+        <br/>
         <GSForm
           schema={this.formSchema}
           value={this.state}
@@ -133,6 +135,52 @@ class CampaignDynamicAssignmentForm extends React.Component {
               message status filter in Message Review. You might set this to 48
               hours for slower campaigns or 2 hours or less for GOTV campaigns.
             </p>
+            <FormControlLabel
+          control={
+            <Switch
+              color="primary"
+              checked={useDynamicReplies || false}
+              onChange={(toggler, val) => {
+                console.log(toggler, val);
+                this.toggleChange("useDynamicReplies", val);
+              }}
+            />
+          }
+          label="Allow texters with a link to dynamically get assigned replies?"
+          labelPlacement="start"
+        />
+
+          {!useDynamicReplies ? null : (
+            <div>
+              <ul>
+                <li>
+                  {joinToken ? (
+                    <OrganizationReassignLink
+                      organizationUuid={joinToken}
+                      campaignId={campaignId}
+                    />
+                  ) : (
+                    "Please save the campaign and reload the page to get the reply link to share with texters."
+                  )}
+                </li>
+                <li>
+                  You can turn off dynamic assignment after starting a campaign
+                  to disallow more new texters to receive replies.
+                </li>
+              </ul>
+
+              <Form.Field
+                as={GSTextField}
+                fullWidth
+                name="replyBatchSize"
+                type="number"
+                label="How large should a batch of replies be?"
+                initialValue={200}
+              />  
+            </div>
+          )
+
+          }
             {organization.batchPolicies.length > 1 ? (
               <div>
                 <h3>Batch Strategy</h3>
@@ -211,7 +259,8 @@ CampaignDynamicAssignmentForm.propTypes = {
   saveDisabled: type.bool,
   joinToken: type.string,
   responseWindow: type.number,
-  batchSize: type.string
+  batchSize: type.string,
+  replyBatchSize: type.string
 };
 
 export default compose(withMuiTheme)(CampaignDynamicAssignmentForm);

--- a/src/components/CampaignDynamicAssignmentForm.jsx
+++ b/src/components/CampaignDynamicAssignmentForm.jsx
@@ -156,7 +156,7 @@ class CampaignDynamicAssignmentForm extends React.Component {
                 <li>
                   {joinToken ? (
                     <OrganizationReassignLink
-                      organizationUuid={joinToken}
+                      joinToken={joinToken}
                       campaignId={campaignId}
                     />
                   ) : (

--- a/src/components/OrganizationReassignLink.jsx
+++ b/src/components/OrganizationReassignLink.jsx
@@ -2,20 +2,20 @@ import PropTypes from "prop-types";
 import React from "react";
 import DisplayLink from "./DisplayLink";
 
-const OrganizationReassignLink = ({ organizationUuid, campaignId }) => {
+const OrganizationReassignLink = ({ joinToken, campaignId }) => {
   let baseUrl = "http://base";
   if (typeof window !== "undefined") {
     baseUrl = window.location.origin;
   }
 
-  const replyUrl = `${baseUrl}/${organizationUuid}/replies/${campaignId}`;
+  const replyUrl = `${baseUrl}/${joinToken}/replies/${campaignId}`;
   const textContent = `Send your texting volunteers this link! Once they sign up, they\'ll be automatically assigned replies for this campaign.`;
 
   return <DisplayLink url={replyUrl} textContent={textContent} />;
 };
 
 OrganizationReassignLink.propTypes = {
-  organizationUuid: PropTypes.string,
+  joinToken: PropTypes.string,
   campaignId: PropTypes.string
 };
 

--- a/src/components/OrganizationReassignLink.jsx
+++ b/src/components/OrganizationReassignLink.jsx
@@ -1,0 +1,22 @@
+import PropTypes from "prop-types";
+import React from "react";
+import DisplayLink from "./DisplayLink";
+
+const OrganizationReassignLink = ({ organizationUuid, campaignId }) => {
+  let baseUrl = "http://base";
+  if (typeof window !== "undefined") {
+    baseUrl = window.location.origin;
+  }
+
+  const replyUrl = `${baseUrl}/${organizationUuid}/replies/${campaignId}`;
+  const textContent = `Send your texting volunteers this link! Once they sign up, they\'ll be automatically assigned replies for this campaign.`;
+
+  return <DisplayLink url={replyUrl} textContent={textContent} />;
+};
+
+OrganizationReassignLink.propTypes = {
+  organizationUuid: PropTypes.string,
+  campaignId: PropTypes.string
+};
+
+export default OrganizationReassignLink;

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -139,6 +139,8 @@ const campaignInfoFragment = `
     state
     count
   }
+  useDynamicReplies
+  replyBatchSize
 `;
 
 export const campaignDataQuery = gql`query getCampaign($campaignId: String!) {
@@ -514,7 +516,9 @@ export class AdminCampaignEditBase extends React.Component {
           "batchSize",
           "useDynamicAssignment",
           "responseWindow",
-          "batchPolicies"
+          "batchPolicies",
+          "useDynamicReplies",
+          "replyBatchSize"
         ],
         checkCompleted: () => true,
         blocksStarting: false,

--- a/src/containers/AssignReplies.jsx
+++ b/src/containers/AssignReplies.jsx
@@ -22,7 +22,7 @@ class AssignReplies extends React.Component {
     try {
       
       const organizationId = (await this.props.mutations.dynamicReassign(
-        this.props.params.organizationUuid,
+        this.props.params.joinToken,
         this.props.params.campaignId
       )).data.dynamicReassign;
       console.log("ID:", organizationId);
@@ -62,11 +62,11 @@ AssignReplies.propTypes = {
 
 export const dynamicReassignMutation = gql`
   mutation dynamicReassign(
-    $organizationUuid: String!
+    $joinToken: String!
     $campaignId: String!
   ) {
     dynamicReassign(
-      organizationUuid: $organizationUuid
+      joinToken: $joinToken
       campaignId: $campaignId
     )
   }
@@ -74,12 +74,12 @@ export const dynamicReassignMutation = gql`
 
 const mutations = {
   dynamicReassign: ownProps => (
-    organizationUuid,
+    joinToken,
     campaignId
   ) => ({
     mutation: dynamicReassignMutation,
     variables: {
-      organizationUuid,
+      joinToken,
       campaignId
     }
   })

--- a/src/containers/AssignReplies.jsx
+++ b/src/containers/AssignReplies.jsx
@@ -1,0 +1,88 @@
+import PropTypes from "prop-types";
+import React from "react";
+import loadData from "./hoc/load-data";
+import gql from "graphql-tag";
+import { withRouter } from "react-router";
+import { StyleSheet, css } from "aphrodite";
+import theme from "../styles/theme";
+
+const styles = StyleSheet.create({
+  greenBox: {
+    ...theme.layouts.greenBox
+  }
+});
+
+class AssignReplies extends React.Component {
+  state = {
+    errors: null
+  };
+
+  async componentWillMount() {
+    console.log("Props",this.props);
+    try {
+      
+      const organizationId = (await this.props.mutations.dynamicReassign(
+        this.props.params.organizationUuid,
+        this.props.params.campaignId
+      )).data.dynamicReassign;
+      console.log("ID:", organizationId);
+
+    this.props.router.push(`/app/${organizationId}`);
+    } catch (err) {
+      console.log("error assigning replies", err);
+      const texterMessage = (err &&
+        err.message &&
+        err.message.match(/(Sorry,.+)$/)) || [
+        0,
+        "Something went wrong trying to assign replies. Please contact your administrator."
+      ];
+      this.setState({
+        errors: texterMessage[1]
+      });
+    }
+  }
+  renderErrors() {
+    if (this.state.errors) {
+      return <div className={css(styles.greenBox)}>{this.state.errors}</div>;
+    }
+    return <div />;
+  }
+
+  render() {
+    return <div>{this.renderErrors()}</div>;
+  }
+}
+
+AssignReplies.propTypes = {
+  mutations: PropTypes.object,
+  router: PropTypes.object,
+  params: PropTypes.object,
+  campaign: PropTypes.object
+};
+
+export const dynamicReassignMutation = gql`
+  mutation dynamicReassign(
+    $organizationUuid: String!
+    $campaignId: String!
+  ) {
+    dynamicReassign(
+      organizationUuid: $organizationUuid
+      campaignId: $campaignId
+    )
+  }
+`;
+
+const mutations = {
+  dynamicReassign: ownProps => (
+    organizationUuid,
+    campaignId
+  ) => ({
+    mutation: dynamicReassignMutation,
+    variables: {
+      organizationUuid,
+      campaignId
+    }
+  })
+};
+
+export default loadData({ mutations })(withRouter(AssignReplies));

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -23,6 +23,7 @@ import CreateOrganization from "./containers/CreateOrganization";
 import CreateAdditionalOrganization from "./containers/CreateAdditionalOrganization";
 import AdminOrganizationsDashboard from "./containers/AdminOrganizationsDashboard";
 import JoinTeam from "./containers/JoinTeam";
+import AssignReplies from "./containers/AssignReplies";
 import Home from "./containers/Home";
 import Settings from "./containers/Settings";
 import Tags from "./containers/Tags";
@@ -273,6 +274,11 @@ export default function makeRoutes(requireAuth = () => {}) {
       <Route
         path="addOrganization/:inviteId"
         component={CreateAdditionalOrganization}
+        onEnter={requireAuth}
+      />
+      <Route
+        path=":organizationUuid/replies/:campaignId"
+        component={AssignReplies}
         onEnter={requireAuth}
       />
       <Route

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -277,7 +277,7 @@ export default function makeRoutes(requireAuth = () => {}) {
         onEnter={requireAuth}
       />
       <Route
-        path=":organizationUuid/replies/:campaignId"
+        path=":joinToken/replies/:campaignId"
         component={AssignReplies}
         onEnter={requireAuth}
       />

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -343,6 +343,15 @@ export const resolvers = {
         ? features.DYNAMICASSIGNMENT_BATCHES.split(",")
         : [];
     },
+
+    replyBatchSize: campaign => {
+      const features = getFeatures(campaign);
+      return features.REPLY_BATCH_SIZE || 200;
+    },
+    useDynamicReplies: campaign => {
+      const features = getFeatures(campaign);
+      return features.USE_DYNAMIC_REPLIES ? features.USE_DYNAMIC_REPLIES : false;
+    },
     responseWindow: campaign => campaign.response_window || 48,
     organization: async (campaign, _, { loaders }) =>
       campaign.organization ||

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -74,6 +74,13 @@ function getConversationsJoinsAndWhereClause(
     contactsFilter && contactsFilter.messageStatus
   );
 
+  if (contactsFilter.updatedAtGt) {
+    query = query.andWhere(function() {this.where('updated_at', '>', contactsFilter.updatedAtGt)})
+  }
+  if (contactsFilter.updatedAtLt) {
+    query = query.andWhere(function() {this.where('updated_at', '<', contactsFilter.updatedAtLt)})
+  }
+
   if (contactsFilter) {
     if ("isOptedOut" in contactsFilter) {
       query.where("is_opted_out", contactsFilter.isOptedOut);
@@ -125,6 +132,10 @@ function getConversationsJoinsAndWhereClause(
             .whereIn("tag_id", tags)
         );
       }
+    }
+
+    if (contactsFilter.orderByRaw) {
+      query = query.orderByRaw(contactsFilter.orderByRaw);
     }
   }
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2,7 +2,7 @@ import GraphQLDate from "graphql-date";
 import GraphQLJSON from "graphql-type-json";
 import { GraphQLError } from "graphql/error";
 import isUrl from "is-url";
-import _, { orderBy } from "lodash";
+import _ from "lodash";
 import { gzip, makeTree, getHighestRole } from "../../lib";
 import { capitalizeWord, groupCannedResponses } from "./lib/utils";
 import httpRequest from "../lib/http-request";
@@ -1441,7 +1441,7 @@ const rootMutations = {
     dynamicReassign: async (
       _,
       {
-        organizationUuid,
+        joinToken,
         campaignId
       },
       { user }
@@ -1451,7 +1451,7 @@ const rootMutations = {
       .knex("campaign")
       .where({
         id: campaignId,
-        join_token: organizationUuid,
+        join_token: joinToken,
       })
       .first();
       const INVALID_REASSIGN = () => {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2,7 +2,7 @@ import GraphQLDate from "graphql-date";
 import GraphQLJSON from "graphql-type-json";
 import { GraphQLError } from "graphql/error";
 import isUrl from "is-url";
-import _ from "lodash";
+import _, { orderBy } from "lodash";
 import { gzip, makeTree, getHighestRole } from "../../lib";
 import { capitalizeWord, groupCannedResponses } from "./lib/utils";
 import httpRequest from "../lib/http-request";
@@ -193,7 +193,9 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     textingHoursStart,
     textingHoursEnd,
     timezone,
-    serviceManagers
+    serviceManagers,
+    useDynamicReplies,
+    replyBatchSize
   } = campaign;
   // some changes require ADMIN and we recheck below
   const organizationId =
@@ -259,6 +261,17 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     });
     campaignUpdates.features = JSON.stringify(features);
   }
+  if (useDynamicReplies) {
+    Object.assign(features, {
+      "USE_DYNAMIC_REPLIES": true,
+      "REPLY_BATCH_SIZE": replyBatchSize
+    })
+  } else {
+    Object.assign(features, {
+      "USE_DYNAMIC_REPLIES": false
+    })
+  }
+  campaignUpdates.features = JSON.stringify(features);
 
   let changed = Boolean(Object.keys(campaignUpdates).length);
   if (changed) {
@@ -1424,6 +1437,64 @@ const rootMutations = {
         campaignIdContactIdsMap,
         newTexterUserId
       );
+    },
+    dynamicReassign: async (
+      _,
+      {
+        organizationUuid,
+        campaignId
+      },
+      { user }
+    ) => {
+      // verify permissions
+      const campaign = await r
+      .knex("campaign")
+      .where({
+        id: campaignId,
+        join_token: organizationUuid,
+      })
+      .first();
+      const INVALID_REASSIGN = () => {
+        const error = new GraphQLError("Invalid reassign request - organization not found");
+        error.code = "INVALID_REASSIGN";
+        return error;
+      };
+      if (!campaign) {
+        throw INVALID_REASSIGN();
+      }
+      const organization = await cacheableData.organization.load(
+        campaign.organization_id
+      );
+      if (!organization) {
+        throw INVALID_REASSIGN();
+      }      
+
+      const maxContacts = getConfig("MAX_REPLIES_PER_TEXTER", organization);
+      let d = new Date();
+      d.setHours(d.getHours() - 1);
+      const contactsFilter = { messageStatus: 'needsResponse', isOptedOut: false, listSize: maxContacts, orderByRaw: "updated_at DESC", updatedAtLt: d}
+      const campaignsFilter = {
+        campaignId: campaignId
+      };
+
+      await accessRequired(
+        user,
+        organization.id,
+        "TEXTER",
+        /* superadmin*/ true
+      );
+      const { campaignIdContactIdsMap } = await getCampaignIdContactIdsMaps(
+        organization.id,
+        {
+          campaignsFilter,
+          contactsFilter,
+        }
+      );
+      await reassignConversations(
+        campaignIdContactIdsMap,
+        user.id
+      );
+      return organization.id;
     },
     importCampaignScript: async (_, { campaignId, url }, { user }) => {
       const campaign = await cacheableData.campaign.load(campaignId);

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1468,8 +1468,7 @@ const rootMutations = {
       if (!organization) {
         throw INVALID_REASSIGN();
       }      
-
-      const maxContacts = getConfig("MAX_REPLIES_PER_TEXTER", organization);
+      const maxContacts = getConfig("MAX_REPLIES_PER_TEXTER", organization) ?? 200;
       let d = new Date();
       d.setHours(d.getHours() - 1);
       const contactsFilter = { messageStatus: 'needsResponse', isOptedOut: false, listSize: maxContacts, orderByRaw: "updated_at DESC", updatedAtLt: d}


### PR DESCRIPTION
# Fixes #2357

## Description

Add a new option under "Dynamic Assignment" under campaign setup which creates a special link.  That link is used to reassign "needs reply" conversations dynamically - whenever a user goes to that link they will receive up to (batch size) conversations that need a reply and have not been reassigned in the past hour.

![Spoke_Dynamic_Replies](https://github.com/MoveOnOrg/Spoke/assets/62553142/dd3336d8-bec2-4c2d-8f68-e3d525538ec5)


# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
